### PR TITLE
Downgrade get-stdin to v4.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "array-uniq": "^1.0.0",
-    "get-stdin": "^5.0.1",
+    "get-stdin": "^4.0.1",
     "meow": "^3.5.0",
     "semver-regex": "^1.0.0"
   },


### PR DESCRIPTION
From v5.x and onwards the get-stdin only works with Node.js v0.12 and above