### PR TITLE
Avoid semver-regex ReDoS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,3 @@ language: node_js
 node_js:
   - '10'
   - '8'
-  - '6'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "find-versions",
-	"version": "3.2.0",
+	"version": "4.0.0",
 	"description": "Find semver versions in a string: `unicorn v1.2.3` → `1.2.3`",
 	"license": "MIT",
 	"repository": "sindresorhus/find-versions",
@@ -10,7 +10,7 @@
 		"url": "sindresorhus.com"
 	},
 	"engines": {
-		"node": ">=6"
+		"node": ">=8"
 	},
 	"scripts": {
 		"test": "xo && ava && tsd"
@@ -33,7 +33,7 @@
 		"get"
 	],
 	"dependencies": {
-		"semver-regex": "^2.0.0"
+		"semver-regex": "^3.1.2"
 	},
 	"devDependencies": {
 		"ava": "^1.4.1",


### PR DESCRIPTION
Some software composition analysis tools like Snyk are flagging versions <3.1.2. This is a major version bump to propagate the Node.js 8 requirement.

https://snyk.io/vuln/SNYK-JS-SEMVERREGEX-1047770